### PR TITLE
Remove gulpfile.js from and add Makefile to .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -3,7 +3,7 @@
 /.travis.yml
 /.tslintrc.json
 /coverage/
-/gulpfile.js
+/Makefile
 /lib.d/
 /lib/**/*.ts
 !/lib/**/*.d.ts


### PR DESCRIPTION
Gulp may be no longer used?
