### PR TITLE
Minor fixes

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -3,7 +3,7 @@
 /.travis.yml
 /.tslintrc.json
 /coverage/
-/gulpfile.js
+/Makefile
 /lib.d/
 /lib/**/*.ts
 !/lib/**/*.d.ts

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 NODE_MODULES_PATH := $(shell pwd)/node_modules
 PATH := $(NODE_MODULES_PATH)/.bin:$(PATH)
+SHELL := /bin/bash
 
 LINT := tslint
 LINT_FLAGS := --config ./.tslintrc.json


### PR DESCRIPTION
1. Gulp may be no longer used, and I replaced `gulpfile.js` to `Makefile` in `.npmignore`.
2. Changing `PATH` in makefiles doesn't apply in OS X. I know it doesn't look meaningful, but anyway adding `SHELL` makes it work.
